### PR TITLE
[feature]: (#145) manual panel length in repair order

### DIFF
--- a/textile/fabric_printing/doctype/print_order/print_order.js
+++ b/textile/fabric_printing/doctype/print_order/print_order.js
@@ -580,6 +580,14 @@ textile.PrintOrder = class PrintOrder extends textile.TextileOrder {
 		this.calculate_totals();
 	}
 
+	manual_panel_length() {
+		this.calculate_totals();
+	}
+
+	panel_length_inch() {
+		this.calculate_totals();
+	}
+
 	uom(doc, cdt, cdn) {
 		let row = frappe.get_doc(cdt, cdn);
 
@@ -629,7 +637,7 @@ textile.PrintOrder = class PrintOrder extends textile.TextileOrder {
 		let defaults = {
 			'design_gap': this.frm.doc.default_gap,
 			'qty': this.frm.doc.default_qty,
-			'uom': this.frm.doc.default_uom,	
+			'uom': this.frm.doc.default_uom,
 			'qty_type': this.frm.doc.default_qty_type,
 			'per_wastage': this.frm.doc.default_wastage,
 			'length_uom': this.frm.doc.default_length_uom,
@@ -658,9 +666,12 @@ textile.PrintOrder = class PrintOrder extends textile.TextileOrder {
 		this.frm.doc.items.forEach(d => {
 			frappe.model.round_floats_in(d);
 
-			d.panel_based_qty = cint(Boolean(d.design_gap));
+			d.panel_based_qty = cint(Boolean(d.design_gap) || d.manual_panel_length);
 
-			d.panel_length_inch = flt(d.design_height) + flt(d.design_gap);
+			if (!d.manual_panel_length) {
+				d.panel_length_inch = flt(d.design_height) + flt(d.design_gap);
+			}
+
 			d.panel_length_meter = d.panel_length_inch * conversion_factors.inch_to_meter;
 			d.panel_length_yard = d.panel_length_meter / conversion_factors.yard_to_meter;
 

--- a/textile/fabric_printing/doctype/print_order/print_order.py
+++ b/textile/fabric_printing/doctype/print_order/print_order.py
@@ -356,9 +356,11 @@ class PrintOrder(TextileOrder):
 			validate_uom_and_qty_type(d)
 			self.round_floats_in(d)
 
-			d.panel_based_qty = cint(bool(d.design_gap))
+			d.panel_based_qty = cint(bool(d.design_gap) or d.manual_panel_length)
 
-			d.panel_length_inch = flt(d.design_height) + flt(d.design_gap)
+			if not d.manual_panel_length:
+				d.panel_length_inch = flt(d.design_height) + flt(d.design_gap)
+
 			d.panel_length_meter = d.panel_length_inch * conversion_factors['inch_to_meter']
 			d.panel_length_yard = d.panel_length_meter / conversion_factors['yard_to_meter']
 

--- a/textile/fabric_printing/doctype/print_order_item/print_order_item.json
+++ b/textile/fabric_printing/doctype/print_order_item/print_order_item.json
@@ -29,6 +29,7 @@
   "design_bom",
   "section_break_dgei8",
   "panel_length_inch",
+  "manual_panel_length",
   "column_break_fakwf",
   "panel_length_meter",
   "column_break_kgepc",
@@ -273,7 +274,8 @@
    "fieldtype": "Float",
    "label": "Panel Length (Inch)",
    "non_negative": 1,
-   "read_only": 1
+   "read_only": 1,
+   "read_only_depends_on": "eval:!doc.manual_panel_length;"
   },
   {
    "fieldname": "panel_length_meter",
@@ -398,12 +400,18 @@
    "label": "Rejected Qty",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "manual_panel_length",
+   "fieldtype": "Check",
+   "label": "Set Panel Length Manually"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-07-23 10:38:48.249248",
+ "modified": "2025-06-02 10:29:13.570829",
  "modified_by": "Administrator",
  "module": "Fabric Printing",
  "name": "Print Order Item",


### PR DESCRIPTION
# 🚀 Feature: Manual Panel Length Support in Print Order

## Summary
This PR adds support for **manual panel length input** in the Print Order line items. This allows users to calculate panel quantities for continuous print designs that do not have a design gap.

---

## Changes Introduced

- Added a new checkbox field `manual_panel_length` to enable manual input of `panel_length_inch`.
- Made `panel_length_inch` editable only when `manual_panel_length` is checked.
- Updated logic so that `panel_based_qty` is true if either:
  - `design_gap` is present, **or**
  - `manual_panel_length` is checked.
- When `manual_panel_length` is true, `panel_length_inch` is used directly from user input.
- Otherwise, `panel_length_inch` is calculated as `design_height + design_gap`.
- Recalculated dependent fields:
  - `panel_length_meter`
  - `panel_length_yard`
  - `panel_qty`
- Updated total fields on the form:
  - `total_print_length`
  - `total_fabric_length`
  - `total_panel_qty`

---

## Trigger Behavior

- `calculate_totals()` is called when:
  - `manual_panel_length` is toggled
  - `panel_length_inch` is updated (only if manual entry is enabled)

---

Closes https://github.com/ParaLogicTech/textile/issues/145
